### PR TITLE
databricks connect details are now optional

### DIFF
--- a/src/databricksbundle/_config/databricks/databricks_connect.yaml
+++ b/src/databricksbundle/_config/databricks/databricks_connect.yaml
@@ -26,12 +26,7 @@ services:
 
   databricksbundle.spark.DatabricksConnectSessionFactory:
     arguments:
-      - '%databricksbundle.databricks_connect.connection.address%'
-      - '%databricksbundle.databricks_connect.connection.token%'
-      - '%databricksbundle.databricks_connect.connection.cluster_id%'
-      - '%databricksbundle.databricks_connect.connection.org_id%'
-      - '%databricksbundle.databricks_connect.connection.port%'
-      - '%databricksbundle.databricks_connect.connection.driver_bind_address%'
+      - '%databricksbundle.databricks_connect.connection%'
       - !tagged databricks_connect.configurator
 
   pyspark.dbutils.DBUtils:

--- a/src/databricksbundle/spark/DatabricksConnectSessionFactory.py
+++ b/src/databricksbundle/spark/DatabricksConnectSessionFactory.py
@@ -1,4 +1,5 @@
-from typing import Optional, List
+from typing import List
+from box import Box
 from pyspark.sql.session import SparkSession
 from pyspark.conf import SparkConf
 from databricksbundle.spark.SparkSessionLazy import SparkSessionLazy
@@ -8,49 +9,39 @@ from databricksbundle.spark.config.ConfiguratorInterface import ConfiguratorInte
 class DatabricksConnectSessionFactory:
     def __init__(
         self,
-        address: str,
-        token: str,
-        cluster_id: str,
-        org_id: Optional[str],
-        port: int,
-        bind_address: Optional[str],
+        config: Box,
         configurators: List[ConfiguratorInterface],
     ):
-        self.__address = address
-        self.__token = token
-        self.__cluster_id = cluster_id
-        self.__org_id = org_id
-        self.__port = port
-        self.__bind_address = bind_address
+        self.__config = config
         self.__configurators = configurators
 
     def create(self) -> SparkSessionLazy:
-        if not self.__address:
-            raise Exception("Databricks workspace address not set")
-
-        if not self.__token:
-            raise Exception("Databricks workspace token not set")
-
-        if not self.__cluster_id:
-            raise Exception("Databricks cluster not set")
-
-        if not self.__port:
-            raise Exception("Databricks connect port not set")
-
         def create_lazy():
+            if not self.__config.address:
+                raise Exception("Databricks workspace address not set")
+
+            if not self.__config.token:
+                raise Exception("Databricks workspace token not set")
+
+            if not self.__config.cluster_id:
+                raise Exception("Databricks cluster not set")
+
+            if not self.__config.port:
+                raise Exception("Databricks connect port not set")
+
             # Databricks Connect configuration must be set before calling getOrCreate()
             conf = SparkConf()
-            conf.set("spark.databricks.service.address", self.__address)
-            conf.set("spark.databricks.service.token", self.__token)
-            conf.set("spark.databricks.service.clusterId", self.__cluster_id)
+            conf.set("spark.databricks.service.address", self.__config.address)
+            conf.set("spark.databricks.service.token", self.__config.token)
+            conf.set("spark.databricks.service.clusterId", self.__config.cluster_id)
 
-            if self.__org_id is not None:
-                conf.set("spark.databricks.service.orgId", self.__org_id)
+            if self.__config.org_id is not None:
+                conf.set("spark.databricks.service.orgId", self.__config.org_id)
 
-            conf.set("spark.databricks.service.port", self.__port)
+            conf.set("spark.databricks.service.port", self.__config.port)
 
-            if self.__bind_address is not None:
-                conf.set("spark.driver.bindAddress", self.__bind_address)
+            if self.__config.driver_bind_address is not None:
+                conf.set("spark.driver.bindAddress", self.__config.driver_bind_address)
 
             spark = SparkSession.builder.config(conf=conf).getOrCreate()
 


### PR DESCRIPTION
User must not be forced to set up databricks connect before he/she deploys some code to standard Databricks web UI