### PR TITLE
Databricks repos detector updated to be applicable also on GCP/AWS

### DIFF
--- a/src/databricksbundle/detector.py
+++ b/src/databricksbundle/detector.py
@@ -12,4 +12,4 @@ def is_databricks():
 
 
 def is_databricks_repo():
-    return is_databricks() and os.getcwd().startswith("/Workspace/Repos")
+    return is_databricks() and "/Repos/" in os.getcwd()

--- a/src/databricksbundle/notebook/GithubLinkGenerator.py
+++ b/src/databricksbundle/notebook/GithubLinkGenerator.py
@@ -21,7 +21,7 @@ class GithubLinkGenerator:
         return module_name[:index_of_bundle] + "-" + module_name[index_of_bundle:]
 
     def __get_module_version(self, module_name: str) -> str:
-        base_path = Path("/".join(list(Path.cwd().parts[0:5])))
+        base_path = Path("/".join(list(Path.cwd().parts[0:Path.cwd().parts.index('Repos') + 3])))
         lockfile_path = base_path.joinpath("poetry.lock")
 
         with lockfile_path.open("r") as f:


### PR DESCRIPTION
Databricks repos detector updated to be applicable to Repos on a platform other than Azure. GithubLinkGenerator CWD path modified accordingly.